### PR TITLE
Add substance-toc repo.

### DIFF
--- a/.screwdriver/project.json
+++ b/.screwdriver/project.json
@@ -21,6 +21,11 @@
       "branch": "master"
     },
     {
+      "repository": "https://github.com/substance/toc.git",
+      "folder": "node_modules/substance-toc",
+      "branch": "lens"
+    },
+    {
       "repository": "https://github.com/substance/util.git",
       "folder": "node_modules/substance-util",
       "branch": "lens"


### PR DESCRIPTION
Tried to `substance --update` but failed. It works for me when I added `https://github.com/substance/toc.git` to the screwdriver project.json.
