### PR TITLE
Use lens develop branch in dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3862,17 +3862,10 @@
       }
     },
     "lens": {
-      "version": "github:elifesciences/lens#b95caa7f31aba72ce8e39177a87cad892b1764cc",
-      "from": "github:elifesciences/lens#2.0.0",
+      "version": "github:elifesciences/lens#beec4c5e66f4cf8143de344c9d2c2ce1be44a71d",
+      "from": "github:elifesciences/lens#develop",
       "requires": {
-        "underscore": "1.8.3"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        }
+        "underscore": "1.12.1"
       }
     },
     "liftoff": {
@@ -3893,7 +3886,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cookie-parser": "^1.4.5",
     "ejs": "^3.1.5",
     "express": "^4.17.1",
-    "lens": "elifesciences/lens.git#2.0.0",
+    "lens": "elifesciences/lens#develop",
     "method-override": "^3.0.0",
     "node-sass": "^5.0.0",
     "underscore": "^1.12.1"


### PR DESCRIPTION
Similar to PR https://github.com/elifesciences/lens-elife/pull/24, but in order to use the latest verison of `underscore`, the branch of `lens` used is switched from a tagged release `2.0.0` (https://github.com/elifesciences/lens/tree/2.0.0) to using the `develop` branch (https://github.com/elifesciences/lens/tree/develop).

If you could please take a look at this @NuclearRedeye for approval or comment. Do you think we should create a new tagged release, like `2.1.0` or something, or just go with the branch name for `lens` library?